### PR TITLE
Added additional sugar 🍬 for matching errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -177,3 +177,10 @@ func errCode(prefix, code string) string {
 func (p *Error) Matches(match string) bool {
 	return strings.Contains(p.Error(), match)
 }
+
+// Matches returns true if the error is a terror error and the string returned from error.Error() contains the given
+// param string. This means you can match the error on different levels e.g. dotted codes `bad_request` or
+// `bad_request.missing_param` or even on the more descriptive message
+func Matches(err error, match string) bool {
+	return Wrap(err, nil).(*Error).Matches(match)
+}

--- a/errors.go
+++ b/errors.go
@@ -181,7 +181,7 @@ func (p *Error) Matches(match string) bool {
 // PrefixMatches returns whether the string returned from error.Error() starts with the given param string. This means
 // you can match the error on different levels e.g. dotted codes `bad_request` or `bad_request.missing_param`.
 func (p *Error) PrefixMatches(prefix string) bool {
-	return strings.HasPrefix(p.Error(), prefix)
+	return strings.HasPrefix(p.Code, prefix)
 }
 
 // Matches returns true if the error is a terror error and the string returned from error.Error() contains the given

--- a/errors.go
+++ b/errors.go
@@ -188,12 +188,20 @@ func (p *Error) PrefixMatches(prefix string) bool {
 // param string. This means you can match the error on different levels e.g. dotted codes `bad_request` or
 // `bad_request.missing_param` or even on the more descriptive message
 func Matches(err error, match string) bool {
-	return Wrap(err, nil).(*Error).Matches(match)
+	if terr, ok := Wrap(err, nil).(*Error); ok {
+		return terr.Matches(match)
+	}
+
+	return false
 }
 
 // PrefixMatches returns true if the error is a terror and the string returned from error.Error() starts with the
 // given param string. This means you can match the error on different levels e.g. dotted codes `bad_request` or
 // `bad_request.missing_param`.
 func PrefixMatches(err error, prefix string) bool {
-	return Wrap(err, nil).(*Error).PrefixMatches(prefix)
+	if terr, ok := Wrap(err, nil).(*Error); ok {
+		return terr.PrefixMatches(prefix)
+	}
+
+	return false
 }

--- a/errors.go
+++ b/errors.go
@@ -178,9 +178,22 @@ func (p *Error) Matches(match string) bool {
 	return strings.Contains(p.Error(), match)
 }
 
+// PrefixMatches returns whether the string returned from error.Error() starts with the given param string. This means
+// you can match the error on different levels e.g. dotted codes `bad_request` or `bad_request.missing_param`.
+func (p *Error) PrefixMatches(prefix string) bool {
+	return strings.HasPrefix(p.Error(), prefix)
+}
+
 // Matches returns true if the error is a terror error and the string returned from error.Error() contains the given
 // param string. This means you can match the error on different levels e.g. dotted codes `bad_request` or
 // `bad_request.missing_param` or even on the more descriptive message
 func Matches(err error, match string) bool {
 	return Wrap(err, nil).(*Error).Matches(match)
+}
+
+// PrefixMatches returns true if the error is a terror and the string returned from error.Error() starts with the
+// given param string. This means you can match the error on different levels e.g. dotted codes `bad_request` or
+// `bad_request.missing_param`.
+func PrefixMatches(err error, prefix string) bool {
+	return Wrap(err, nil).(*Error).PrefixMatches(prefix)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -136,3 +136,29 @@ func TestMatches(t *testing.T) {
 	assert.False(t, Matches(err, ErrBadRequest+".missing_param.foo1"))
 	assert.True(t, Matches(err, "You need to pass a value for foo"))
 }
+
+func TestPrefixMatchesMethod(t *testing.T) {
+	err := &Error{
+		Code:    "bad_request.missing_param.foo",
+		Message: "You need to pass a value for foo; try passing foo=bar",
+	}
+	assert.True(t, err.PrefixMatches(ErrBadRequest))
+	assert.True(t, err.PrefixMatches(ErrBadRequest+".missing_param"))
+	assert.False(t, err.PrefixMatches(ErrInternalService))
+	assert.False(t, err.PrefixMatches(ErrBadRequest+".missing_param.foo1"))
+	assert.False(t, err.PrefixMatches("You need to pass a value for foo"))
+	assert.False(t, err.PrefixMatches("missing_param"))
+}
+
+func TestPrefixMatches(t *testing.T) {
+	err := &Error{
+		Code:    "bad_request.missing_param.foo",
+		Message: "You need to pass a value for foo; try passing foo=bar",
+	}
+	assert.True(t, PrefixMatches(err, ErrBadRequest))
+	assert.True(t, PrefixMatches(err, ErrBadRequest+".missing_param"))
+	assert.False(t, PrefixMatches(err, ErrInternalService))
+	assert.False(t, PrefixMatches(err, ErrBadRequest+".missing_param.foo1"))
+	assert.False(t, PrefixMatches(err, "You need to pass a value for foo"))
+	assert.False(t, PrefixMatches(err, "missing_param"))
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -135,6 +135,7 @@ func TestMatches(t *testing.T) {
 	assert.False(t, Matches(err, ErrInternalService))
 	assert.False(t, Matches(err, ErrBadRequest+".missing_param.foo1"))
 	assert.True(t, Matches(err, "You need to pass a value for foo"))
+	assert.False(t, Matches(nil, ErrBadRequest))
 }
 
 func TestPrefixMatchesMethod(t *testing.T) {
@@ -161,4 +162,5 @@ func TestPrefixMatches(t *testing.T) {
 	assert.False(t, PrefixMatches(err, ErrBadRequest+".missing_param.foo1"))
 	assert.False(t, PrefixMatches(err, "You need to pass a value for foo"))
 	assert.False(t, PrefixMatches(err, "missing_param"))
+	assert.False(t, PrefixMatches(nil, ErrBadRequest))
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -113,7 +113,7 @@ func TestNilError(t *testing.T) {
 	assert.Nil(t, Wrap(nil, nil))
 }
 
-func TestMatches(t *testing.T) {
+func TestMatchesMethod(t *testing.T) {
 	err := &Error{
 		Code:    "bad_request.missing_param.foo",
 		Message: "You need to pass a value for foo; try passing foo=bar",
@@ -123,5 +123,16 @@ func TestMatches(t *testing.T) {
 	assert.False(t, err.Matches(ErrInternalService))
 	assert.False(t, err.Matches(ErrBadRequest+".missing_param.foo1"))
 	assert.True(t, err.Matches("You need to pass a value for foo"))
+}
 
+func TestMatches(t *testing.T) {
+	err := &Error{
+		Code:    "bad_request.missing_param.foo",
+		Message: "You need to pass a value for foo; try passing foo=bar",
+	}
+	assert.True(t, Matches(err, ErrBadRequest))
+	assert.True(t, Matches(err, ErrBadRequest+".missing_param"))
+	assert.False(t, Matches(err, ErrInternalService))
+	assert.False(t, Matches(err, ErrBadRequest+".missing_param.foo1"))
+	assert.True(t, Matches(err, "You need to pass a value for foo"))
 }


### PR DESCRIPTION
Testing whether an error matches a given prefix is not as complicated by the need to cast to a `*terrors.Error`. This wrapper method contains some sugar to make this easier.