### PR TITLE
wrap: wrap now adds parameters instead of discarding them when the er…

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -100,7 +100,7 @@ func WrapWithCode(err error, params map[string]string, code string) error {
 	}
 	switch err := err.(type) {
 	case *Error:
-		return err
+		return addParams(err, params)
 	default:
 		return errorFactory(code, err.Error(), params)
 	}
@@ -189,6 +189,24 @@ func errCode(prefix, code string) string {
 		return code
 	}
 	return strings.Join([]string{prefix, code}, ".")
+}
+
+// addParams returns a new error with new params merged into the original error's
+func addParams(err *Error, params map[string]string) *Error {
+	copiedParams := make(map[string]string, len(err.Params)+len(params))
+	for k, v := range err.Params {
+		copiedParams[k] = v
+	}
+	for k, v := range params {
+		copiedParams[k] = v
+	}
+
+	return &Error{
+		Code:        err.Code,
+		Message:     err.Message,
+		Params:      copiedParams,
+		StackFrames: err.StackFrames,
+	}
 }
 
 // Matches returns whether the string returned from error.Error() contains the given param string. This means you can

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/monzo/terrors/stack"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,8 +71,9 @@ func TestNew(t *testing.T) {
 
 func TestWrapWithWrappedErr(t *testing.T) {
 	err := &Error{
-		Code:    ErrForbidden,
-		Message: "Some message",
+		Code:        ErrForbidden,
+		Message:     "Some message",
+		StackFrames: stack.BuildStack(0),
 		Params: map[string]string{
 			"something old": "caesar",
 		},
@@ -81,10 +83,12 @@ func TestWrapWithWrappedErr(t *testing.T) {
 		"something new": "a computer",
 	}).(*Error)
 
-	assert.Equal(t, wrappedErr, err)
-	assert.Equal(t, ErrForbidden, wrappedErr.Code)
+	assert.Equal(t, err.Code, wrappedErr.Code)
+	assert.Equal(t, err.StackFrames, wrappedErr.StackFrames)
+	assert.Equal(t, err.Message, wrappedErr.Message)
 	assert.Equal(t, wrappedErr.Params, map[string]string{
 		"something old": "caesar",
+		"something new": "a computer",
 	})
 
 }


### PR DESCRIPTION
We found ourselves wanting to add new context to errors even when they were already `Errors`. This PR adds that behaviours, which should make the errors we capture contain more useful information for debugging.