### PR TITLE
Add special case for context cancelation errors

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package terrors
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
@@ -106,6 +107,12 @@ func TestWrap(t *testing.T) {
 		"blub": "dub",
 	})
 
+}
+
+func TestWrapContextCanceled(t *testing.T) {
+	err := context.Canceled
+	wrappedErr := Wrap(err, nil).(*Error)
+	assert.Equal(t, ErrContextCanceled, wrappedErr.Code)
 }
 
 func getNilErr() error {


### PR DESCRIPTION
_This feels a bit hacky, and I'd love some thoughts if there's a better way to achieve this._

When using [Typhon](https://github.com/monzo/typhon)'s [HttpService](https://github.com/monzo/typhon/blob/5c63e484c906f6a870d60e188b13c9beada0645f/client.go#L44) which uses a [RoundTripper](https://github.com/monzo/typhon/blob/5c63e484c906f6a870d60e188b13c9beada0645f/client.go#L47) the request cancelation is represented as an error equal to [context.Canceled](https://golang.org/pkg/context/#pkg-variables). The Typhon HttpService wraps the error returned by the roundtripper using `terrors.Wrap(err, nil)` which results in the errorFactory producing an `ErrInternalService`, which is hard to distinguish further up the request chain.

I'd like to be able to distinguish these context cancellations with a unique error of some form.

- Add an error to represent `context.Canceled` - `ErrContextCanceled`
- Add special case in the errorFactory to catch this (works, maintains the interface, but feels bad)