### PR TITLE
Read stack trace more efficiently

### DIFF
--- a/stack/stack.go
+++ b/stack/stack.go
@@ -29,8 +29,8 @@ type Stack []*Frame
 func BuildStack(skip int) Stack {
 	stack := make(Stack, 0)
 
-	// Look up to a maximum depth of 20
-	ret := make([]uintptr, 20)
+	// Look up to a maximum depth of 100
+	ret := make([]uintptr, 100)
 
 	// Note that indexes must be one higher when passed to Callers()
 	// than they would be when passed to Caller()

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -29,19 +29,33 @@ type Stack []*Frame
 func BuildStack(skip int) Stack {
 	stack := make(Stack, 0)
 
-	for i := skip; ; i++ {
-		pc, file, line, ok := runtime.Caller(i)
-		if !ok {
-			break
-		}
-		file = shortenFilePath(file)
-		stack = append(stack, &Frame{
-			Filename: file,
-			Method:   functionName(pc),
-			Line:     line,
-		})
+	// Look up to a maximum depth of 20
+	ret := make([]uintptr, 20)
+
+	// Note that indexes must be one higher when passed to Callers()
+	// than they would be when passed to Caller()
+	// see https://golang.org/pkg/runtime/#Caller
+	index := runtime.Callers(skip+1, ret)
+	if index == 0 {
+		// We have no frames to report, skip must be too high
+		return stack
 	}
 
+	// This function takes a list of counters and gets function/file/line information
+	cf := runtime.CallersFrames(ret[:index])
+
+	for {
+		frame, ok := cf.Next()
+		stack = append(stack, &Frame{
+			Filename: shortenFilePath(frame.File),
+			Method:   functionName(frame.PC),
+			Line:     frame.Line,
+		})
+		if !ok {
+			// This was the last valid caller
+			break
+		}
+	}
 	return stack
 }
 


### PR DESCRIPTION
Iterating over `runtime.Caller` is apparently discouraged. Instead we can run `runtime.Callers` and get a list of program counters, and then give these to `runtime.CallersFrames` to iterate over frame info for each. See https://golang.org/src/runtime/extern.go?#L198

This PR significantly increases the performance of getting stack traces when being called by lots of goroutines many times. We believe terrors may have caused performance issues in `service.platform.authentication` which returns lots of errors.