### PR TITLE
Try and find a stack trace frame which is outside of terrors for logparams

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,9 +19,8 @@ package terrors
 
 import (
 	"fmt"
-	"strings"
-
 	"strconv"
+	"strings"
 
 	"github.com/monzo/terrors/stack"
 )

--- a/errors.go
+++ b/errors.go
@@ -21,8 +21,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/monzo/terrors/stack"
 	"strconv"
+
+	"github.com/monzo/terrors/stack"
 )
 
 // Error is terror's error. It implements Go's error interface.
@@ -88,10 +89,18 @@ func (p *Error) LogMetadata() map[string]string {
 		return p.Params
 	}
 
+	// Attempt to find a frame that isn't within the terrors library.
+	var frame *stack.Frame
+	for _, frame = range p.StackFrames {
+		if !strings.HasPrefix(frame.Method, "terrors.") {
+			break
+		}
+	}
+
 	logParams := map[string]string{
-		"terrors_file":     p.StackFrames[0].Filename,
-		"terrors_function": p.StackFrames[0].Method,
-		"terrors_line":     strconv.Itoa(p.StackFrames[0].Line),
+		"terrors_file":     frame.Filename,
+		"terrors_function": frame.Method,
+		"terrors_line":     strconv.Itoa(frame.Line),
 	}
 
 	for key, value := range p.Params {

--- a/errors_test.go
+++ b/errors_test.go
@@ -15,9 +15,8 @@ func TestLogParams(t *testing.T) {
 	err := New("service.foo", "Some message", map[string]string{"public": "value"})
 
 	assert.Equal(t, "value", err.LogMetadata()["public"])
-	assert.Equal(t, "15", err.LogMetadata()["terrors_line"])
-	assert.Equal(t, "terrors.TestLogParams", err.LogMetadata()["terrors_function"])
-	assert.Equal(t, "github.com/monzo/terrors/errors_test.go", err.LogMetadata()["terrors_file"])
+	assert.Equal(t, "777", err.LogMetadata()["terrors_line"])
+	assert.Equal(t, "testing.tRunner", err.LogMetadata()["terrors_function"])
 }
 
 func TestErrorConstructors(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -15,7 +15,6 @@ func TestLogParams(t *testing.T) {
 	err := New("service.foo", "Some message", map[string]string{"public": "value"})
 
 	assert.Equal(t, "value", err.LogMetadata()["public"])
-	assert.Equal(t, "777", err.LogMetadata()["terrors_line"])
 	assert.Equal(t, "testing.tRunner", err.LogMetadata()["terrors_function"])
 }
 


### PR DESCRIPTION
If it cant find one, it returns the highest frame in the stack trace