### PR TITLE
Include the Program Counter in terror stack traces

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -100,6 +100,7 @@ func (p *Error) LogMetadata() map[string]string {
 		"terrors_file":     frame.Filename,
 		"terrors_function": frame.Method,
 		"terrors_line":     strconv.Itoa(frame.Line),
+		"terrors_pc":       strconv.FormatUint(uint64(frame.PC), 10),
 	}
 
 	for key, value := range p.Params {

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -19,9 +19,10 @@ var (
 )
 
 type Frame struct {
-	Filename string `json:"filename"`
-	Method   string `json:"method"`
-	Line     int    `json:"lineno"`
+	Filename string  `json:"filename"`
+	Method   string  `json:"method"`
+	Line     int     `json:"lineno"`
+	PC       uintptr `json:"pc"`
 }
 
 type Stack []*Frame
@@ -50,6 +51,7 @@ func BuildStack(skip int) Stack {
 			Filename: shortenFilePath(frame.File),
 			Method:   functionName(frame.PC),
 			Line:     frame.Line,
+			PC:       frame.PC,
 		})
 		if !ok {
 			// This was the last valid caller

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -24,20 +24,20 @@ func TestStackFingerprint(t *testing.T) {
 		{
 			"9344290d",
 			Stack{
-				&Frame{"foo.go", "Oops", 1},
+				&Frame{"foo.go", "Oops", 1, 0},
 			},
 		},
 		{
 			"a4d78b7",
 			Stack{
-				&Frame{"foo.go", "Oops", 2},
+				&Frame{"foo.go", "Oops", 2, 0},
 			},
 		},
 		{
 			"50e0fcb3",
 			Stack{
-				&Frame{"foo.go", "Oops", 1},
-				&Frame{"foo.go", "Oops", 2},
+				&Frame{"foo.go", "Oops", 1, 0},
+				&Frame{"foo.go", "Oops", 2, 0},
 			},
 		},
 	}


### PR DESCRIPTION
This allows downstream consumers (say, the CLI or a Typhon filter) to reconstruct accurate stack traces.