### PR TITLE
Terrors had some weird, inconsistent behaviour between %s and .Error()

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -76,10 +76,6 @@ func (p *Error) VerboseString() string {
 	return fmt.Sprintf("%s\nParams: %+v\n%s", p.Error(), p.Params, p.StackString())
 }
 
-func (p *Error) Format(f fmt.State, c rune) {
-	f.Write([]byte(p.Message))
-}
-
 // LogMetadata implements the logMetadataProvider interface in the slog library which means that
 // the error params will automatically be merged with the slog metadata.
 // Additionally we put stack data in here for slog use.


### PR DESCRIPTION
```
err := terrors.BadRequest("test error")
fmt.Println(err) // "test error"
fmt.Println(err.Error()) // "bad_request: test error"
fmt.Fprint("%s", err) // "test error"
fmt.Fprint("%v", err) // "test error"
```

Normally when you print an error, you get the result of `Error()` - but `*terrors.Error` also implements `Format()`, which has higher priority… and prints just the message.