### PR TITLE
Let PrefixMatches accept multiple prefix parts

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -253,8 +253,12 @@ func (p *Error) Matches(match string) bool {
 }
 
 // PrefixMatches returns whether the string returned from error.Error() starts with the given param string. This means
-// you can match the error on different levels e.g. dotted codes `bad_request` or `bad_request.missing_param`.
-func (p *Error) PrefixMatches(prefix string) bool {
+// you can match the error on different levels e.g. dotted codes `bad_request` or `bad_request.missing_param`. Each
+// dotted part can be passed as a separate argument e.g. `terr.PrefixMatches(terrors.ErrBadRequest, "missing_param")`
+// is the same as `terr.PrefixMatches("bad_request.missing_param")`
+func (p *Error) PrefixMatches(prefixParts ...string) bool {
+	prefix := strings.Join(prefixParts, ".")
+
 	return strings.HasPrefix(p.Code, prefix)
 }
 
@@ -271,10 +275,12 @@ func Matches(err error, match string) bool {
 
 // PrefixMatches returns true if the error is a terror and the string returned from error.Error() starts with the
 // given param string. This means you can match the error on different levels e.g. dotted codes `bad_request` or
-// `bad_request.missing_param`.
-func PrefixMatches(err error, prefix string) bool {
+// `bad_request.missing_param`. Each dotted part can be passed as a separate argument
+// e.g. `terrors.PrefixMatches(terr, terrors.ErrBadRequest, "missing_param")` is the same as
+// terrors.PrefixMatches(terr, "bad_request.missing_param")`
+func PrefixMatches(err error, prefixParts ...string) bool {
 	if terr, ok := Wrap(err, nil).(*Error); ok {
-		return terr.PrefixMatches(prefix)
+		return terr.PrefixMatches(prefixParts...)
 	}
 
 	return false

--- a/errors_test.go
+++ b/errors_test.go
@@ -157,8 +157,10 @@ func TestPrefixMatchesMethod(t *testing.T) {
 	}
 	assert.True(t, err.PrefixMatches(ErrBadRequest))
 	assert.True(t, err.PrefixMatches(ErrBadRequest+".missing_param"))
+	assert.True(t, err.PrefixMatches(ErrBadRequest, "missing_param"))
 	assert.False(t, err.PrefixMatches(ErrInternalService))
 	assert.False(t, err.PrefixMatches(ErrBadRequest+".missing_param.foo1"))
+	assert.False(t, err.PrefixMatches(ErrBadRequest, "missing_param", "foo1"))
 	assert.False(t, err.PrefixMatches("You need to pass a value for foo"))
 	assert.False(t, err.PrefixMatches("missing_param"))
 }
@@ -170,8 +172,10 @@ func TestPrefixMatches(t *testing.T) {
 	}
 	assert.True(t, PrefixMatches(err, ErrBadRequest))
 	assert.True(t, PrefixMatches(err, ErrBadRequest+".missing_param"))
+	assert.True(t, PrefixMatches(err, ErrBadRequest, "missing_param"))
 	assert.False(t, PrefixMatches(err, ErrInternalService))
 	assert.False(t, PrefixMatches(err, ErrBadRequest+".missing_param.foo1"))
+	assert.False(t, PrefixMatches(err, ErrBadRequest, "missing_param", "foo1"))
 	assert.False(t, PrefixMatches(err, "You need to pass a value for foo"))
 	assert.False(t, PrefixMatches(err, "missing_param"))
 	assert.False(t, PrefixMatches(nil, ErrBadRequest))


### PR DESCRIPTION
When prefix matching it's extremely common to match on dotted codes with
more than one part. e.g. `bad_request.missing_param`. Currently this
either involves slightly ugly string concatenation by the caller e.g.
`terrors.ErrBadRequest+".missing_param"` or hard-coding top level dotted
parts e.g. `bad_request.missing_param`.

This change makes PrefixMatches a variadic function that can accept
mutliple string arguments, and automatically concatenates the strings as
dotted parts. Removing the need for the caller to do it. It provides a
little bit of sugar that should make correctly composing error codes
much easier.