### PR TITLE
Update go build versions for Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: go
 
 go:
-  - 1.8.x
-  - 1.9.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin


### PR DESCRIPTION
Go lint no longer support go versions < 1.9. So updating go versions to more recent go versions.

https://go-review.googlesource.com/c/tools/+/142896