### PR TITLE
[BP-338] Improve support for wrapping and unwrapping errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin

--- a/errors.go
+++ b/errors.go
@@ -129,17 +129,15 @@ func New(code string, message string, params map[string]string) *Error {
 	return errorFactory(nil, code, message, params)
 }
 
-// Wrap takes any error interface and wraps it into an Error.
+// Propagate takes any error interface and wraps it into an Error.
 // This is useful because an Error contains lots of useful goodies, like the stacktrace of the error.
-// NOTE: If `err` is already an `Error`, it will add the params passed in to the params of the Error
-func Wrap(err error, params map[string]string) error {
-	return WrapWithCode(err, params, ErrInternalService)
-}
-
+// NOTE: If `cause` is already an `Error`, it will merge the message and params with the underlying Error
 func Propagate(cause error, msg string, params map[string]string) error {
 	return PropagateWithCode(cause, ErrInternalService, msg, params)
 }
 
+// PropagateWithCode wraps an error with a custom error code.
+// NOTE: If `cause` is already an `Error`, it will merge the message and params with the underlying Error
 func PropagateWithCode(cause error, code string, msg string, params map[string]string) error {
 	if cause == nil {
 		return nil
@@ -169,8 +167,21 @@ func PropagateWithCode(cause error, code string, msg string, params map[string]s
 	}
 }
 
+// Wrap takes any error interface and wraps it into an Error.
+// This is useful because an Error contains lots of useful goodies, like the stacktrace of the error.
+// NOTE: If `err` is already an `Error`, it will add the params passed in to the params of the Error
+//
+// Deprecated: Wrap exists for historical compatability and should not be used.
+// To add context to an existing error, use `Propagate` instead.
+func Wrap(err error, params map[string]string) error {
+	return WrapWithCode(err, params, ErrInternalService)
+}
+
 // WrapWithCode wraps an error with a custom error code. If `err` is already
 // an `Error`, it will add the params passed in to the params of the error
+//
+// Deprecated: WrapWithCode exists for historical compatability and should not be used.
+// To add context to an existing error with a code, use `PropagateWithCode` instead.
 func WrapWithCode(err error, params map[string]string, code string) error {
 	if err == nil {
 		return nil

--- a/errors.go
+++ b/errors.go
@@ -136,6 +136,8 @@ func WrapWithCode(err error, params map[string]string, code string, messages ...
 		return nil
 	}
 
+	// We're using a variadic function here but only a single message is actually used.
+	// This is designed to ensure backwards compatability for usages without a message.
 	message := ""
 	if len(messages) > 0 {
 		message = messages[0]

--- a/errors.go
+++ b/errors.go
@@ -36,8 +36,7 @@ type Error struct {
 	// one of the `Propagate...` methods are used (the deprecated `Wrap` methods
 	// do not set the `cause` property to maintain backwards compatability).
 	// Because errors cannot be serialised as JSON this field is left unexported.
-	// This means that the cause of an error cannot be examined across service
-	// boundaries.
+	// This means that the cause of an error cannot be examined across service boundaries.
 	cause error
 }
 

--- a/errors.go
+++ b/errors.go
@@ -250,6 +250,7 @@ func addParams(err *Error, params map[string]string) *Error {
 		Message:     err.Message,
 		Params:      copiedParams,
 		StackFrames: err.StackFrames,
+		err:         err,
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package terrors
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -10,6 +11,14 @@ import (
 )
 
 type newError func(code, message string, params map[string]string) *Error
+
+type customError struct {
+	message string
+}
+
+func (c *customError) Error() string {
+	return c.message
+}
 
 func TestLogParams(t *testing.T) {
 	err := New("service.foo", "Some message", map[string]string{"public": "value"})
@@ -112,7 +121,19 @@ func TestWrap(t *testing.T) {
 	assert.Equal(t, wrappedErr.Params, map[string]string{
 		"blub": "dub",
 	})
+}
 
+func TestWrappedErrorsCanBeUnwrapped(t *testing.T) {
+	err := &customError{"foo"}
+	wrappedErr := Wrap(err, map[string]string{
+		"bar": "baz",
+	})
+
+	var unwrappedErr *customError
+	match := errors.As(wrappedErr, &unwrappedErr)
+
+	assert.True(t, match)
+	assert.Equal(t, err, unwrappedErr)
 }
 
 func getNilErr() error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,7 +1,6 @@
 package terrors
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -123,45 +122,45 @@ func TestWrap(t *testing.T) {
 	})
 }
 
-func TestWrapErrorWithMessage(t *testing.T) {
-	err := fmt.Errorf("Look here, an error")
-	wrappedErr := Wrap(err, nil, "loading data").(*Error)
+// func TestWrapErrorWithMessage(t *testing.T) {
+// 	err := fmt.Errorf("Look here, an error")
+// 	wrappedErr := Wrap(err, nil, "loading data").(*Error)
 
-	assert.Equal(t, "internal_service: loading data: Look here, an error", wrappedErr.Error())
-	assert.Equal(t, "loading data: Look here, an error", wrappedErr.Message)
-}
+// 	assert.Equal(t, "internal_service: loading data: Look here, an error", wrappedErr.Error())
+// 	assert.Equal(t, "loading data: Look here, an error", wrappedErr.Message)
+// }
 
-func TestWrapTerrorWithMessage(t *testing.T) {
-	err := BadRequest("name", "invalid name", nil)
-	wrappedErr := Wrap(err, nil, "loading data").(*Error)
+// func TestWrapTerrorWithMessage(t *testing.T) {
+// 	err := BadRequest("name", "invalid name", nil)
+// 	wrappedErr := Wrap(err, nil, "loading data").(*Error)
 
-	assert.Equal(t, "bad_request.name: loading data: invalid name", wrappedErr.Error())
-	assert.Equal(t, "loading data: invalid name", wrappedErr.Message)
-}
+// 	assert.Equal(t, "bad_request.name: loading data: invalid name", wrappedErr.Error())
+// 	assert.Equal(t, "loading data: invalid name", wrappedErr.Message)
+// }
 
-func TestWrappedErrorCanBeUnwrapped(t *testing.T) {
-	err := &customError{"foo"}
-	wrappedErr := Wrap(err, nil)
+// func TestWrappedErrorCanBeUnwrapped(t *testing.T) {
+// 	err := &customError{"foo"}
+// 	wrappedErr := Wrap(err, nil)
 
-	assert.True(t, errors.Is(wrappedErr, err))
+// 	assert.True(t, errors.Is(wrappedErr, err))
 
-	var unwrappedErr *customError
-	errors.As(wrappedErr, &unwrappedErr)
+// 	var unwrappedErr *customError
+// 	errors.As(wrappedErr, &unwrappedErr)
 
-	assert.Equal(t, err, unwrappedErr)
-}
+// 	assert.Equal(t, err, unwrappedErr)
+// }
 
-func TestWrappedTerrorCanBeUnwrapped(t *testing.T) {
-	err := &customError{"foo"}
-	doubleWrappedErr := Wrap(Wrap(err, nil), nil)
+// func TestWrappedTerrorCanBeUnwrapped(t *testing.T) {
+// 	err := &customError{"foo"}
+// 	doubleWrappedErr := Wrap(Wrap(err, nil), nil)
 
-	assert.True(t, errors.Is(doubleWrappedErr, err))
+// 	assert.True(t, errors.Is(doubleWrappedErr, err))
 
-	var unwrappedErr *customError
-	errors.As(doubleWrappedErr, &unwrappedErr)
+// 	var unwrappedErr *customError
+// 	errors.As(doubleWrappedErr, &unwrappedErr)
 
-	assert.Equal(t, err, unwrappedErr)
-}
+// 	assert.Equal(t, err, unwrappedErr)
+// }
 
 func getNilErr() error {
 	return Wrap(nil, nil)

--- a/errors_test.go
+++ b/errors_test.go
@@ -136,6 +136,17 @@ func TestWrappedErrorsCanBeUnwrapped(t *testing.T) {
 	assert.Equal(t, err, unwrappedErr)
 }
 
+func TestWrappedTerrorsCanBeUnwrapped(t *testing.T) {
+	err := &customError{"foo"}
+	doubleWrappedErr := Wrap(Wrap(err, nil), nil)
+
+	var unwrappedErr *customError
+	match := errors.As(doubleWrappedErr, &unwrappedErr)
+
+	assert.True(t, match)
+	assert.Equal(t, err, unwrappedErr)
+}
+
 func getNilErr() error {
 	return Wrap(nil, nil)
 }

--- a/errors_test.go
+++ b/errors_test.go
@@ -123,7 +123,7 @@ func TestWrap(t *testing.T) {
 	})
 }
 
-func TestWrapWithMessage(t *testing.T) {
+func TestWrapErrorWithMessage(t *testing.T) {
 	err := fmt.Errorf("Look here, an error")
 	wrappedErr := Wrap(err, nil, "loading data").(*Error)
 
@@ -131,7 +131,7 @@ func TestWrapWithMessage(t *testing.T) {
 	assert.Equal(t, "loading data: Look here, an error", wrappedErr.Message)
 }
 
-func TestTerrorWrapWithMessage(t *testing.T) {
+func TestWrapTerrorWithMessage(t *testing.T) {
 	err := BadRequest("name", "invalid name", nil)
 	wrappedErr := Wrap(err, nil, "loading data").(*Error)
 
@@ -139,7 +139,7 @@ func TestTerrorWrapWithMessage(t *testing.T) {
 	assert.Equal(t, "loading data: invalid name", wrappedErr.Message)
 }
 
-func TestWrappedErrorsCanBeUnwrapped(t *testing.T) {
+func TestWrappedErrorCanBeUnwrapped(t *testing.T) {
 	err := &customError{"foo"}
 	wrappedErr := Wrap(err, nil)
 
@@ -150,7 +150,7 @@ func TestWrappedErrorsCanBeUnwrapped(t *testing.T) {
 	assert.Equal(t, err, unwrappedErr)
 }
 
-func TestWrappedTerrorsCanBeUnwrapped(t *testing.T) {
+func TestWrappedTerrorCanBeUnwrapped(t *testing.T) {
 	err := &customError{"foo"}
 	doubleWrappedErr := Wrap(Wrap(err, nil), nil)
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -125,9 +125,7 @@ func TestWrap(t *testing.T) {
 
 func TestWrappedErrorsCanBeUnwrapped(t *testing.T) {
 	err := &customError{"foo"}
-	wrappedErr := Wrap(err, map[string]string{
-		"bar": "baz",
-	})
+	wrappedErr := Wrap(err, nil)
 
 	var unwrappedErr *customError
 	match := errors.As(wrappedErr, &unwrappedErr)

--- a/errors_test.go
+++ b/errors_test.go
@@ -143,10 +143,11 @@ func TestWrappedErrorCanBeUnwrapped(t *testing.T) {
 	err := &customError{"foo"}
 	wrappedErr := Wrap(err, nil)
 
-	var unwrappedErr *customError
-	match := errors.As(wrappedErr, &unwrappedErr)
+	assert.True(t, errors.Is(wrappedErr, err))
 
-	assert.True(t, match)
+	var unwrappedErr *customError
+	errors.As(wrappedErr, &unwrappedErr)
+
 	assert.Equal(t, err, unwrappedErr)
 }
 
@@ -154,10 +155,11 @@ func TestWrappedTerrorCanBeUnwrapped(t *testing.T) {
 	err := &customError{"foo"}
 	doubleWrappedErr := Wrap(Wrap(err, nil), nil)
 
-	var unwrappedErr *customError
-	match := errors.As(doubleWrappedErr, &unwrappedErr)
+	assert.True(t, errors.Is(doubleWrappedErr, err))
 
-	assert.True(t, match)
+	var unwrappedErr *customError
+	errors.As(doubleWrappedErr, &unwrappedErr)
+
 	assert.Equal(t, err, unwrappedErr)
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -123,6 +123,22 @@ func TestWrap(t *testing.T) {
 	})
 }
 
+func TestWrapWithMessage(t *testing.T) {
+	err := fmt.Errorf("Look here, an error")
+	wrappedErr := Wrap(err, nil, "loading data").(*Error)
+
+	assert.Equal(t, "internal_service: loading data: Look here, an error", wrappedErr.Error())
+	assert.Equal(t, "loading data: Look here, an error", wrappedErr.Message)
+}
+
+func TestTerrorWrapWithMessage(t *testing.T) {
+	err := BadRequest("name", "invalid name", nil)
+	wrappedErr := Wrap(err, nil, "loading data").(*Error)
+
+	assert.Equal(t, "bad_request.name: loading data: invalid name", wrappedErr.Error())
+	assert.Equal(t, "loading data: invalid name", wrappedErr.Message)
+}
+
 func TestWrappedErrorsCanBeUnwrapped(t *testing.T) {
 	err := &customError{"foo"}
 	wrappedErr := Wrap(err, nil)


### PR DESCRIPTION
This PR introduces two new features for wrapping errors:
1. Adding additional information to error messages when errors are wrapped
2. Unwrapping errors with support for `errors.Is` and `errors.As` in [Go 1.13 onwards](https://blog.golang.org/go1.13-errors)

These changes are implemented in two new `Propagate` and `PropagateWithCode` methods. This allows us to leave the behaviour of the existing `Wrap` and `WrapWithCode` methods completely unchanged. The intention would be to ultimately deprecate the old methods. (Method names inspired by https://github.com/palantir/stacktrace)

⚠️ This is an early draft PR for exploration and feedback. I don't intend to merge it as is, but developing these features in a single branch allows me to test them out in `wearedev` easily.

### Background

In the Backend Platform team we're looking at ways to [surface deviant systems behaviour](https://www.notion.so/monzo/What-we-re-working-on-Surfacing-deviant-system-behaviour-9f02d8df3b95434a85773ac3d80be8bf). One of the features we're exploring is logging errors returned by RPC handlers by default. This would mean that instead of calling `slog` from within your handler, you simply return an error and it would be logged for you (by a new Typhon filter).

One of the benefits of calling `slog` from within a handler (as we do now) is that you can add additional context about what went wrong using the log message and the log params. It often looks like this:

```golang
slog.Error(ctx, "Failed to update preferred emoji: %v", err, slogParams)
```

where `slogParams` is a map of useful context, typically extracted from the request body.

In a world where the `slog` call happens outside of the RPC handler, all of the additional context you would want to include about an error needs to be contained within the error itself.

Using `terrors.Wrap` is a good candidate for this as it allows you to easily add structured parameters to an existing (t)error. However, it doesn't support adding information to the error message (like `errors.Wrap` or `fmt.Errorf("bla: %w")` do.

This PR adds a `terrors.Propagate` method that supports adding information to the wrapped error message in the same way:

```go
err := errors.New("database connection reset")
terr := terrors.Propagate(err, "updating preferred emoji", params)
fmt.Println(terr)
// => internal_service: updating preferred emoji: database connection reset
```

You can see a [more complete example](https://github.com/monzo/wearedev/pull/54104/files) of how this might change how we do error handling in a real service.

This PR also implements an `Unwrap` method which allows for unwrapping errors using `errors.Is` and `errors.As`. This only returns the underlying error for `Error`s created using `Propagate` or `PropagateWithCode` to avoid accidentally breaking existing checks that use `Wrap` or `WrapWithCode`.

https://mondough.atlassian.net/browse/BP-338