### PR TITLE
Add support for propagating/wrapping errors and maintaining causes.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -158,6 +158,15 @@ func New(code string, message string, params map[string]string) *Error {
 	return errorFactory(code, message, params)
 }
 
+// NewInternalWithCause creates a new Terror from an existing error.
+// The new error will always have the code `ErrInternalService`. The original
+// error is attached as the `cause`, and can be tested with the `Is` function.
+func NewInternalWithCause(err error, message string, params map[string]string) *Error {
+	newErr := errorFactory(ErrInternalService, message, params)
+	newErr.cause = err
+	return newErr
+}
+
 // addParams returns a new error with new params merged into the original error's
 func addParams(err *Error, params map[string]string) *Error {
 	copiedParams := make(map[string]string, len(err.Params)+len(params))
@@ -227,17 +236,8 @@ func Propagate(err error, context string, params map[string]string) error {
 		terr.cause = err
 		return terr
 	default:
-		return FromDownstream(err, context, params)
+		return NewInternalWithCause(err, context, params)
 	}
-}
-
-// FromDownstream creates a new Terror from an existing error.
-// The new error will always have the code `ErrInternalService`. The original
-// error is attached as the `cause`, and can be tested with the `Is` function.
-func FromDownstream(err error, message string, params map[string]string) *Error {
-	newErr := errorFactory(ErrInternalService, message, params)
-	newErr.cause = err
-	return newErr
 }
 
 // Is checks whether an error is a given code. Similarly to `errors.Is`,

--- a/errors.go
+++ b/errors.go
@@ -52,28 +52,6 @@ const (
 // Error returns a string message of the error. It is a concatenation of Code and Message params
 // This means the Error implements the error interface
 func (p *Error) Error() string {
-	// var next error = p
-	// output := strings.Builder{}
-	// first := true
-	// for next != nil {
-	// 	if !first {
-	// 		output.WriteString(" ")
-	// 	}
-	// 	switch typed := next.(type) {
-	// 	case *Error:
-	// 		output.WriteString(typed.errString())
-	// 		next = typed.cause
-	// 	case error:
-	// 		output.WriteString(typed.Error())
-	// 		next = nil
-	// 	}
-	// 	first = false
-	// }
-	// return output.String()
-	return p.errString()
-}
-
-func (p *Error) errString() string {
 	if p == nil {
 		return ""
 	}

--- a/errors.go
+++ b/errors.go
@@ -95,6 +95,8 @@ func (p *Error) legacyErrString() string {
 	return fmt.Sprintf("%s: %s", p.Code, p.Message)
 }
 
+// Unwrap retruns the cause of the error. It may be nil.
+// WARNING: This function is considered experimental, and may be changed without notice.
 func (p *Error) Unwrap() error {
 	return p.cause
 }
@@ -161,6 +163,7 @@ func New(code string, message string, params map[string]string) *Error {
 // NewInternalWithCause creates a new Terror from an existing error.
 // The new error will always have the code `ErrInternalService`. The original
 // error is attached as the `cause`, and can be tested with the `Is` function.
+// WARNING: This function is considered experimental, and may be changed without notice.
 func NewInternalWithCause(err error, message string, params map[string]string) *Error {
 	newErr := errorFactory(ErrInternalService, message, params)
 	newErr.cause = err
@@ -228,6 +231,7 @@ func PrefixMatches(err error, prefixParts ...string) bool {
 
 // Propagate adds context to an existing error.
 // If the error given is not already a terror, a new terror is created.
+// WARNING: This function is considered experimental, and may be changed without notice.
 func Propagate(err error, context string, params map[string]string) error {
 	switch err := err.(type) {
 	case *Error:
@@ -246,6 +250,7 @@ func Propagate(err error, context string, params map[string]string) error {
 // We prefer this over using a method receiver on the terrors Error, as the function
 // signature requires an error to test against, and checking against terrors would
 // requite creating a new terror with the specific code.
+// WARNING: This function is considered experimental, and may be changed without notice.
 func Is(err error, code ...string) bool {
 	switch err := err.(type) {
 	case *Error:

--- a/errors_test.go
+++ b/errors_test.go
@@ -375,3 +375,9 @@ func TestIsError(t *testing.T) {
 		})
 	}
 }
+
+func TestFromDownstreamStack(t *testing.T) {
+	err := FromDownstream(assert.AnError, "test", nil)
+	// Ensure that the first callsite is this method rather than the terrors internals
+	assert.Contains(t, err.StackFrames[0].Method, "TestFromDownstreamStack")
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -350,19 +350,19 @@ func TestIsError(t *testing.T) {
 			expectedMatch: false,
 		},
 		{
-			desc: "created FromDownstream",
+			desc: "created NewInternalWithCause",
 			errCreator: func() error {
 				base := NotFound("foo", "bar", nil)
-				return FromDownstream(base, "added context", nil)
+				return NewInternalWithCause(base, "added context", nil)
 			},
 			code:          []string{ErrNotFound},
 			expectedMatch: true,
 		},
 		{
-			desc: "created FromDownstream wrong code",
+			desc: "created NewInternalWithCause wrong code",
 			errCreator: func() error {
 				base := NotFound("foo", "bar", nil)
-				return FromDownstream(base, "added context", nil)
+				return NewInternalWithCause(base, "added context", nil)
 			},
 			code:          []string{ErrForbidden},
 			expectedMatch: false,
@@ -376,8 +376,8 @@ func TestIsError(t *testing.T) {
 	}
 }
 
-func TestFromDownstreamStack(t *testing.T) {
-	err := FromDownstream(assert.AnError, "test", nil)
+func TestNewInternalWithCauseStack(t *testing.T) {
+	err := NewInternalWithCause(assert.AnError, "test", nil)
 	// Ensure that the first callsite is this method rather than the terrors internals
-	assert.Contains(t, err.StackFrames[0].Method, "TestFromDownstreamStack")
+	assert.Contains(t, err.StackFrames[0].Method, "TestNewInternalWithCauseStack")
 }

--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,113 @@
+package terrors
+
+import (
+	"strings"
+
+	"github.com/monzo/terrors/stack"
+)
+
+// Wrap takes any error interface and wraps it into an Error.
+// This is useful because an Error contains lots of useful goodies, like the stacktrace of the error.
+// NOTE: If `err` is already an `Error`, it will add the params passed in to the params of the Error
+func Wrap(err error, params map[string]string) error {
+	return WrapWithCode(err, params, ErrInternalService)
+}
+
+// WrapWithCode wraps an error with a custom error code. If `err` is already
+// an `Error`, it will add the params passed in to the params of the error
+func WrapWithCode(err error, params map[string]string, code string) error {
+	if err == nil {
+		return nil
+	}
+	switch err := err.(type) {
+	case *Error:
+		return addParams(err, params)
+	default:
+		return errorFactory(code, err.Error(), params)
+	}
+}
+
+// InternalService creates a new error to represent an internal service error.
+// Only use internal service error if we know very little about the error. Most
+// internal service errors will come from `Wrap`ing a vanilla `error` interface
+func InternalService(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrInternalService, code), message, params)
+}
+
+// BadRequest creates a new error to represent an error caused by the client sending
+// an invalid request. This is non-retryable unless the request is modified.
+func BadRequest(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrBadRequest, code), message, params)
+}
+
+// BadResponse creates a new error representing a failure to response with a valid response
+// Examples of this would be a handler returning an invalid message format
+func BadResponse(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrBadResponse, code), message, params)
+}
+
+// Timeout creates a new error representing a timeout from client to server
+func Timeout(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrTimeout, code), message, params)
+}
+
+// NotFound creates a new error representing a resource that cannot be found. In some
+// cases this is not an error, and would be better represented by a zero length slice of elements
+func NotFound(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrNotFound, code), message, params)
+}
+
+// Forbidden creates a new error representing a resource that cannot be accessed with
+// the current authorisation credentials. The user may need authorising, or if authorised,
+// may not be permitted to perform this action
+func Forbidden(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrForbidden, code), message, params)
+}
+
+// Unauthorized creates a new error indicating that authentication is required,
+// but has either failed or not been provided.
+func Unauthorized(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrUnauthorized, code), message, params)
+}
+
+// PreconditionFailed creates a new error indicating that one or more conditions
+// given in the request evaluated to false when tested on the server.
+func PreconditionFailed(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrPreconditionFailed, code), message, params)
+}
+
+// errorConstructor returns a `*Error` with the specified code, message and params.
+// Builds a stack based on the current call stack
+func errorFactory(code string, message string, params map[string]string) *Error {
+	err := &Error{
+		Code:    ErrUnknown,
+		Message: message,
+		Params:  map[string]string{},
+	}
+	if len(code) > 0 {
+		err.Code = code
+	}
+	if params != nil {
+		err.Params = params
+	}
+
+	// TODO pass in context.Context
+
+	// Build stack and skip first three lines:
+	//  - stack.go BuildStack()
+	//  - errors.go errorFactory()
+	//  - errors.go public constructor method
+	err.StackFrames = stack.BuildStack(3)
+
+	return err
+}
+
+func errCode(prefix, code string) string {
+	if code == "" {
+		return prefix
+	}
+	if prefix == "" {
+		return code
+	}
+	return strings.Join([]string{prefix, code}, ".")
+}


### PR DESCRIPTION
This PR adds a few new functions to terrors. These functions are intended to provide a new mechanism for wrapping and propagating errors, in line with recent changes in Go. We add:

1. `terrors.Propagate` - This allows wrapping an error with context, and keeping the orignal error as the `cause`.
2. `terrors.Is` - A way to check the causal chain of errors for codes. In many cases, this should replace `terrors.PrefixMatches` when dealing with errors.
3. `terrors.NewInternalWithCause` - A way to create a new InternalService error, wrapping the existing one with a cause. This can be used at service boundaries to create a new error whilst persisting the cause for examination with `Is`.

This effectively deprecates the `Wrap` functionality that exists, but we will not mark this as deprecated whilst this change is still considered experimental.

For extra context on the usages of this change internal to Monzo, you can read: https://www.notion.so/monzo/Error-Propagation-Changes-b896a57667e746008bd31420af364a03

