### PR TITLE
Capture stack trace in propagate. Add subcode support for NewInternal…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: go
 
 go:
-  - 1.11.x
-  - 1.12.x
   - 1.13.x
+  - 1.14.x
 
 install:
   - export PATH=${PATH}:${HOME}/gopath/bin


### PR DESCRIPTION
*Capture stack trace in propagate.*
This allows the user to inspect stack traces throughout the causal chain. It's useful in the case that the original stack trace is captured in a different goroutine, and we'd like to inspect what happened at the first call to propagate.

*Add subcode support for NewInternalWithCause*
This allows users to differentiate the error created with `NewInternalWithCause` from any other `ErrInternalService` by supplying a custom sub-code.