### PR TITLE
Add StackTrace adapter for sentry

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -101,6 +101,16 @@ func (p *Error) Unwrap() error {
 	return p.cause
 }
 
+// StackTrace returns a slice of program counters taken from the stack frames.
+// This adapts the terrors package to allow stacks to be reported to Sentry correctly.
+func (p *Error) StackTrace() []uintptr {
+	out := make([]uintptr, len(p.StackFrames))
+	for i := 0; i < len(p.StackFrames); i++ {
+		out[i] = p.StackFrames[i].PC
+	}
+	return out
+}
+
 // StackString formats the stack as a beautiful string with newlines
 func (p *Error) StackString() string {
 	stackStr := ""

--- a/errors_test.go
+++ b/errors_test.go
@@ -417,3 +417,17 @@ func TestPropagate(t *testing.T) {
 		assert.Greater(t, len(terr.StackFrames), 0)
 	})
 }
+
+func TestStackTrace(t *testing.T) {
+	t.Run("nil stack", func(t *testing.T) {
+		terr := &Error{}
+		res := terr.StackTrace()
+		assert.Len(t, res, 0)
+	})
+	t.Run("non-nil stack", func(t *testing.T) {
+		terr := InternalService("foo", "bar", nil)
+		res := terr.StackTrace()
+		// Don't assert on content because it changes
+		assert.NotEmpty(t, res)
+	})
+}


### PR DESCRIPTION
This exposes program counters with a specific signature so that they can be ready by the sentry library.