### PR TITLE
Removed terrors_ log metadata

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -19,7 +19,6 @@ package terrors
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/monzo/terrors/stack"
@@ -129,39 +128,7 @@ func (p *Error) VerboseString() string {
 // the error params will automatically be merged with the slog metadata.
 // Additionally we put stack data in here for slog use.
 func (p *Error) LogMetadata() map[string]string {
-	if len(p.StackFrames) == 0 {
-		return p.Params
-	}
-
-	// Attempt to find a frame that isn't within the terrors library.
-	var frames []*stack.Frame
-	for _, f := range p.StackFrames {
-		if !strings.HasPrefix(f.Method, "terrors.") {
-			frames = append(frames, f)
-		}
-	}
-	if len(frames) == 0 {
-		return p.Params
-	}
-
-	stackPCs := make([]string, len(frames))
-	for i, f := range frames {
-		stackPCs[i] = strconv.FormatUint(uint64(f.PC), 10)
-	}
-
-	logParams := map[string]string{
-		"terrors_file":     frames[0].Filename,
-		"terrors_function": frames[0].Method,
-		"terrors_line":     strconv.Itoa(frames[0].Line),
-		"terrors_pc":       strconv.FormatUint(uint64(frames[0].PC), 10),
-		"terrors_stack":    strings.Join(stackPCs, ","),
-	}
-
-	for key, value := range p.Params {
-		logParams[key] = value
-	}
-
-	return logParams
+	return p.Params
 }
 
 // New creates a new error for you. Use this if you want to pass along a custom error code.

--- a/errors_test.go
+++ b/errors_test.go
@@ -15,7 +15,6 @@ func TestLogParams(t *testing.T) {
 	err := New("service.foo", "Some message", map[string]string{"public": "value"})
 
 	assert.Equal(t, "value", err.LogMetadata()["public"])
-	assert.Equal(t, "testing.tRunner", err.LogMetadata()["terrors_function"])
 }
 
 func TestErrorConstructors(t *testing.T) {
@@ -199,56 +198,6 @@ func ExampleMatches() {
 	err := NotFound("handler_missing", "Handler not found", nil)
 	fmt.Println(Matches(err, "not_found.handler_missing"))
 	// Output: true
-}
-
-func TestLogMetadataStack(t *testing.T) {
-	t.Run("No stack", func(t *testing.T) {
-		terr := BadRequest("beep", "boop", nil)
-		terr.StackFrames = nil
-		assert.Equal(t, map[string]string{}, terr.LogMetadata())
-	})
-	t.Run("Inside terrors", func(t *testing.T) {
-		terr := BadRequest("beep", "boop", nil)
-		terr.StackFrames = stack.Stack{
-			&stack.Frame{
-				Method:   "terrors.SomeFunc",
-				Filename: "/src/github.com/monzo/terrors/errors.go",
-				Line:     50,
-				PC:       69,
-			},
-		}
-		assert.Equal(t, map[string]string{}, terr.LogMetadata())
-	})
-	t.Run("Outside", func(t *testing.T) {
-		terr := BadRequest("beep", "boop", nil)
-		terr.StackFrames = stack.Stack{
-			&stack.Frame{
-				Method:   "terrors.SomeFunc",
-				Filename: "/src/github.com/monzo/terrors/errors.go",
-				Line:     50,
-				PC:       69,
-			},
-			&stack.Frame{
-				Method:   "typhon.SomeFunc",
-				Filename: "/src/github.com/monzo/typhon/blah.go",
-				Line:     43,
-				PC:       420,
-			},
-			&stack.Frame{
-				Method:   "typhon.SomeOtherFunc",
-				Filename: "/src/github.com/monzo/typhon/blah.go",
-				Line:     39,
-				PC:       573,
-			},
-		}
-		assert.Equal(t, map[string]string{
-			"terrors_file":     "/src/github.com/monzo/typhon/blah.go",
-			"terrors_function": "typhon.SomeFunc",
-			"terrors_line":     "43",
-			"terrors_pc":       "420",
-			"terrors_stack":    "420,573",
-		}, terr.LogMetadata())
-	})
 }
 
 func TestAugmentError(t *testing.T) {


### PR DESCRIPTION
This removes the `terrors_` stack data from the `LogMetadata` function. This data is available under `StackFrames` if consumers want to use it. 
