### PR TITLE
Return early if Propagate and Augment receive a nil err

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -212,6 +212,9 @@ func PrefixMatches(err error, prefixParts ...string) bool {
 // If the error given is not already a terror, a new terror is created.
 // WARNING: This function is considered experimental, and may be changed without notice.
 func Augment(err error, context string, params map[string]string) error {
+	if err == nil {
+		return nil
+	}
 	switch err := err.(type) {
 	case *Error:
 		withMergedParams := addParams(err, params)
@@ -235,6 +238,9 @@ func Augment(err error, context string, params map[string]string) error {
 // chain functionality.
 // WARNING: This function is considered experimental, and may be changed without notice.
 func Propagate(err error) error {
+	if err == nil {
+		return nil
+	}
 	switch err := err.(type) {
 	case *Error:
 		return err

--- a/errors_test.go
+++ b/errors_test.go
@@ -5,8 +5,9 @@ import (
 	"os"
 	"testing"
 
-	"github.com/monzo/terrors/stack"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/monzo/terrors/stack"
 )
 
 type newError func(code, message string, params map[string]string) *Error
@@ -229,6 +230,12 @@ func TestAugmentTerror(t *testing.T) {
 	assert.Equal(t, base, terr.cause)
 }
 
+func TestAugmentNil(t *testing.T) {
+	assert.Nil(t, Augment(nil, "added context", map[string]string{
+		"new": "meta",
+	}))
+}
+
 func TestIsError(t *testing.T) {
 	cases := []struct {
 		desc          string
@@ -364,6 +371,9 @@ func TestPropagate(t *testing.T) {
 		assert.Equal(t, assert.AnError, terr.cause)
 		assert.Equal(t, assert.AnError.Error(), terr.Message)
 		assert.Greater(t, len(terr.StackFrames), 0)
+	})
+	t.Run("nil", func(t *testing.T) {
+		assert.Nil(t, Propagate(nil))
 	})
 }
 


### PR DESCRIPTION
This patch makes Propagate and Augment return early if the provided
error is nil.