### PR TITLE
Remove experimental warnings

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -105,7 +105,6 @@ func (p *Error) legacyErrString() string {
 }
 
 // Unwrap retruns the cause of the error. It may be nil.
-// WARNING: This function is considered experimental, and may be changed without notice.
 func (p *Error) Unwrap() error {
 	return p.cause
 }
@@ -165,7 +164,6 @@ func New(code string, message string, params map[string]string) *Error {
 // error is attached as the `cause`, and can be tested with the `Is` function.
 // You probably want to use the `Augment` func instead;
 // only use this if you need to set a subcode on an error.
-// WARNING: This function is considered experimental, and may be changed without notice.
 func NewInternalWithCause(err error, message string, params map[string]string, subCode string) *Error {
 	newErr := errorFactory(errCode(ErrInternalService, subCode), message, params)
 	newErr.cause = err
@@ -245,7 +243,6 @@ func PrefixMatches(err error, prefixParts ...string) bool {
 
 // Augment adds context to an existing error.
 // If the error given is not already a terror, a new terror is created.
-// WARNING: This function is considered experimental, and may be changed without notice.
 func Augment(err error, context string, params map[string]string) error {
 	if err == nil {
 		return nil
@@ -272,7 +269,6 @@ func Augment(err error, context string, params map[string]string) error {
 // create one, and set the given error as the cause.
 // This is a drop-in replacement for `terrors.Wrap(err, nil)` which adds causal
 // chain functionality.
-// WARNING: This function is considered experimental, and may be changed without notice.
 func Propagate(err error) error {
 	if err == nil {
 		return nil
@@ -291,7 +287,6 @@ func Propagate(err error) error {
 // We prefer this over using a method receiver on the terrors Error, as the function
 // signature requires an error to test against, and checking against terrors would
 // requite creating a new terror with the specific code.
-// WARNING: This function is considered experimental, and may be changed without notice.
 func Is(err error, code ...string) bool {
 	switch err := err.(type) {
 	case *Error:


### PR DESCRIPTION
These functions are now preferred usage inside Monzo, so we should remove the experimental warnings on them.