### PR TITLE
Add terrors.IsRetryable(err error) helper

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -243,6 +243,15 @@ func PrefixMatches(err error, prefixParts ...string) bool {
 	return false
 }
 
+// IsRetryable returns true if the error is a terror and whether the error was caused by an action which can be
+// retried.
+func IsRetryable(err error) bool {
+	if terr, ok := Wrap(err, nil).(*Error); ok {
+		return terr.Retryable()
+	}
+	return false
+}
+
 // Augment adds context to an existing error.
 // If the error given is not already a terror, a new terror is created.
 // WARNING: This function is considered experimental, and may be changed without notice.

--- a/errors.go
+++ b/errors.go
@@ -43,6 +43,7 @@ var retryableCodes = []string{
 	ErrInternalService,
 	ErrTimeout,
 	ErrUnknown,
+	ErrRateLimited,
 }
 
 // Error is terror's error. It implements Go's error interface.

--- a/errors.go
+++ b/errors.go
@@ -257,7 +257,7 @@ func PrefixMatches(err error, prefixParts ...string) bool {
 // IsRetryable returns true if the error is a terror and whether the error was caused by an action which can be
 // retried.
 func IsRetryable(err error) bool {
-	if r, ok := Wrap(err, nil).(*Error); ok {
+	if r, ok := Propagate(err).(*Error); ok {
 		return r.Retryable()
 	}
 	return false

--- a/errors_test.go
+++ b/errors_test.go
@@ -201,10 +201,18 @@ func TestIsRetryable(t *testing.T) {
 	assert.False(t, IsRetryable(WrapWithCode(errors.New(""), nil, ErrBadRequest)))
 
 	// Check that IsRetryable honors errors that implement terrors.retryableError
+	// (after already being converted to a terror)
 	assert.False(t, IsRetryable(Augment(&testRetryableError{false}, "", nil)))
 	assert.False(t, IsRetryable(Propagate(&testRetryableError{false})))
 	assert.True(t, IsRetryable(Augment(&testRetryableError{true}, "", nil)))
 	assert.True(t, IsRetryable(Propagate(&testRetryableError{true})))
+
+	// Check that IsRetryable honors errors that implement terrors.retryableError
+	// (without having been converted to a terror yet)
+	assert.False(t, IsRetryable(&testRetryableError{false}))
+	assert.False(t, IsRetryable(&testRetryableError{false}))
+	assert.True(t, IsRetryable(&testRetryableError{true}))
+	assert.True(t, IsRetryable(&testRetryableError{true}))
 }
 
 type testRetryableError struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,6 +1,7 @@
 package terrors
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -185,6 +186,19 @@ func TestPrefixMatches(t *testing.T) {
 	assert.False(t, PrefixMatches(err, "You need to pass a value for foo"))
 	assert.False(t, PrefixMatches(err, "missing_param"))
 	assert.False(t, PrefixMatches(nil, ErrBadRequest))
+}
+
+func TestIsRetryable(t *testing.T) {
+	assert.False(t, IsRetryable(BadRequest("", "", nil)))
+	assert.False(t, IsRetryable(BadResponse("", "", nil)))
+	assert.False(t, IsRetryable(NotFound("", "", nil)))
+	assert.False(t, IsRetryable(PreconditionFailed("", "", nil)))
+	assert.True(t, IsRetryable(InternalService("", "", nil)))
+	assert.True(t, IsRetryable(RateLimited("", "", nil)))
+	assert.True(t, IsRetryable(errors.New("")))
+	assert.True(t, IsRetryable(Augment(errors.New(""), "", nil)))
+	assert.True(t, IsRetryable(Wrap(errors.New(""), nil)))
+	assert.False(t, IsRetryable(WrapWithCode(errors.New(""), nil, ErrBadRequest)))
 }
 
 func ExampleWrapWithCode() {

--- a/errors_test.go
+++ b/errors_test.go
@@ -199,6 +199,24 @@ func TestIsRetryable(t *testing.T) {
 	assert.True(t, IsRetryable(Augment(errors.New(""), "", nil)))
 	assert.True(t, IsRetryable(Wrap(errors.New(""), nil)))
 	assert.False(t, IsRetryable(WrapWithCode(errors.New(""), nil, ErrBadRequest)))
+
+	// Check that IsRetryable honors errors that implement terrors.retryableError
+	assert.False(t, IsRetryable(Augment(&testRetryableError{false}, "", nil)))
+	assert.False(t, IsRetryable(Propagate(&testRetryableError{false})))
+	assert.True(t, IsRetryable(Augment(&testRetryableError{true}, "", nil)))
+	assert.True(t, IsRetryable(Propagate(&testRetryableError{true})))
+}
+
+type testRetryableError struct {
+	retryable bool
+}
+
+func (e *testRetryableError) Retryable() bool {
+	return e.retryable
+}
+
+func (*testRetryableError) Error() string {
+	return ""
 }
 
 func ExampleWrapWithCode() {


### PR DESCRIPTION
This PR adds a new helper function `terrors.IsRetryable(err error)`, similar to `terrors.PrefixMatches()` etc.

This is intended to make it more convenient for engineers to write Kafka consumers without needing to cast `error`s to `terrors.Error`. For example:

```go
func handleKafkaEvent(
	ctx context.Context,
	event ...,
) streams.ResultWithDeadletter {

	if err := doStuff(ctx, event); err != nil {

		if terrors.IsRetryable(err) {
			// tell kafka to retry
			return streams.Failure{Error: err}
		}

		// no point retrying
		return streams.ImmediateDeadLetter{Error: err}
	}

	return streams.Success{}
}
```

Internally, `terrors.IsRetryable(err error)` calls `Error.IsRetryable()`.