### PR TITLE
Clarify when `Is` behaves differently to `PrefixMatches`

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -309,7 +309,7 @@ func Propagate(err error) error {
 // this unwinds the error stack and checks each underlying error for the code.
 // If any match, this returns true.
 // Note that Is only behaves differently to PrefixMatches when errors in the stack have different codes.
-// This is the case when errors are initialized with NewInternalWithCause, but not with Augment.
+// For example, this is the case when errors are initialized with NewInternalWithCause, but not with Augment.
 // We prefer this over using a method receiver on the terrors Error, as the function
 // signature requires an error to test against, and checking against terrors would
 // requite creating a new terror with the specific code.

--- a/errors.go
+++ b/errors.go
@@ -308,6 +308,8 @@ func Propagate(err error) error {
 // Is checks whether an error is a given code. Similarly to `errors.Is`,
 // this unwinds the error stack and checks each underlying error for the code.
 // If any match, this returns true.
+// Note that Is only behaves differently to PrefixMatches when errors in the stack have different codes.
+// This is the case when errors are initialized with NewInternalWithCause, but not with Augment.
 // We prefer this over using a method receiver on the terrors Error, as the function
 // signature requires an error to test against, and checking against terrors would
 // requite creating a new terror with the specific code.


### PR DESCRIPTION
Based on a quick read of the function definition/docs, I had
assumed that `Is` was used to match errors in a stack created by
calls to `Augment`.

This is not the case since `Augment` duplicates the
code from the wrapped error to the wrapping error.

It is only when used in conjunction with `NewInternalWithCause`
that `Is` is useful.

I'm hoping that this documentation helps clarify this. I'm in two
minds about whether it actually helps, so I'd be interested
to here what you think.