### PR TITLE
terrors.Augment prepends context

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -253,7 +253,7 @@ func TestAugmentError(t *testing.T) {
 	})
 	terr := newErr.(*Error)
 	assert.Equal(t, "internal_service", terr.Code)
-	assert.Equal(t, "added context", terr.Message)
+	assert.Equal(t, "added context: assert.AnError general error for testing", terr.Message)
 
 	assert.Equal(t, "internal_service: added context: assert.AnError general error for testing", terr.Error())
 	assert.Equal(t, "data", terr.Params["meta"])
@@ -269,11 +269,12 @@ func TestAugmentTerror(t *testing.T) {
 	})
 	terr := newErr.(*Error)
 	assert.Equal(t, "not_found.foo", terr.Code)
-	assert.Equal(t, "added context", terr.Message)
+	assert.Equal(t, "added context: failed to find foo", terr.Message)
 	assert.Empty(t, terr.StackFrames)
 
 	assert.Equal(t, "not_found.foo: added context: failed to find foo", terr.Error())
 	assert.Equal(t, base, terr.cause)
+
 }
 
 func TestAugmentNil(t *testing.T) {


### PR DESCRIPTION
Consider the call chain below, where A takes input from a user:
```
A --> B --> C --> D
```
If D throws an unrecoverable error (e.g. `BadRequest` caused by bad data received from A, genuine `NotFound` or `Unauthorized`), we need to propagate the reasoning back to A. Right now we currently override the value of the terror `Message` with the passed `context`, and clients need to walk down the stack to find the root cause.

PR changes terrors.Augment to add context to the existing message, rather than completely replacing it. We may want to change this to only apply to 4xx family errors, but wanted to throw it up for conversation before spending too much time on the problem.
