### PR TITLE
Update documentation and replace the deprecated function Wrap with Augment

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ Terrors is built and used at [Monzo](https://monzo.com/).
 
 ## Usage
 
-Terrors can be used to wrap any object that satisfies the error interface:
+Terrors can be used to add context to an existing error that satisfies the error interface:
+
 
 ```go
-terr := terrors.Wrap(err, map[string]string{"context": "my_context"})
+terr := terrors.Augment(err, "Message", map[string]string{"context": "my_context"})
 ```
 Terrors can be instantiated directly:
 


### PR DESCRIPTION
The documentation gives an example of the Wrap function which is now deprecated. 

This commit replaces the [Wrap](https://github.com/monzo/terrors/blob/master/factory.go#L16) example with an [Augment](https://github.com/monzo/terrors/blob/master/errors.go#L275) example which is the suggested function to use instead.
