### PR TITLE
Keep cause error context when calling Wrap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .DS_Store
+.AppleDouble
+.LSOverride
+.idea
+.vscode
+coverage.out

--- a/errors.go
+++ b/errors.go
@@ -4,14 +4,17 @@
 // user defined error parameters.
 //
 // Terrors can be used to wrap any object that satisfies the error interface:
+//
 //	terr := terrors.Wrap(err, map[string]string{"context": "my_context"})
 //
 // Terrors can be instantiated directly:
-// 	err := terrors.New("not_found", "object not found", map[string]string{
+//
+//	err := terrors.New("not_found", "object not found", map[string]string{
 //		"context": "my_context"
 //	})
 //
 // Terrors offers built-in functions for instantiating Errors with common codes:
+//
 //	err := terrors.NotFound("config_file", "config file not found", map[string]string{
 //		"context": my_context
 //	})
@@ -208,6 +211,7 @@ func addParams(err *Error, params map[string]string) *Error {
 		Params:      copiedParams,
 		StackFrames: err.StackFrames,
 		IsRetryable: err.IsRetryable,
+		cause:       err.cause,
 	}
 }
 
@@ -237,7 +241,9 @@ func (p *Error) PrefixMatches(prefixParts ...string) bool {
 // `PrefixMatches`, so if you were previously matching against a part of the string returned from error.Error() that
 // is _not_ the prefix, then this will be a breaking change. In this case you should update the string to match the
 // prefix. If this is not possible, you can match against the entire error string explicitly, for example:
-//  strings.Contains(err.Error(), "context deadline exceeded")
+//
+//	strings.Contains(err.Error(), "context deadline exceeded")
+//
 // But we consider this bad practice and is part of the motivation for deprecating Matches in the first place.
 func Matches(err error, match string) bool {
 	if terr, ok := Wrap(err, nil).(*Error); ok {

--- a/errors_test.go
+++ b/errors_test.go
@@ -276,6 +276,15 @@ func TestAugmentTerror(t *testing.T) {
 	assert.Equal(t, base, terr.cause)
 }
 
+func TestAugmentTerrorWithWrap(t *testing.T) {
+	base := NotFound("foo", "failed to find foo", map[string]string{"base": "meta"})
+	augmentedErr := Augment(base, "added context", map[string]string{"new": "meta"})
+	assert.Equal(t, "not_found.foo: added context: failed to find foo", augmentedErr.Error())
+
+	wrappedErr := Wrap(augmentedErr, map[string]string{"wrap": "meta"})
+	assert.Equal(t, "not_found.foo: added context: failed to find foo", wrappedErr.Error())
+}
+
 func TestAugmentNil(t *testing.T) {
 	assert.Nil(t, Augment(nil, "added context", map[string]string{
 		"new": "meta",


### PR DESCRIPTION
This PR tweaks the behaviour of Wrap (and WrapWithCode) to propagate the upstream error cause fields across error frames. 

This means when we call `Wrap`, we don't lose the downstream cause. In [160095be57c603739e2c86249245bb808790ecc4](https://github.com/monzo/terrors/commit/160095be57c603739e2c86249245bb808790ecc4), I added a test case of the behaviour I expect and the behaviour we see prior to this change. 