### PR TITLE
feat: append to MessageChain in NewInternalWithCause

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -183,6 +183,13 @@ func NewInternalWithCause(err error, message string, params map[string]string, s
 	newErr.cause = err
 
 	switch v := err.(type) {
+	case *Error:
+		newErr.MessageChain = append([]string{v.Message}, v.MessageChain...)
+	default:
+		newErr.MessageChain = []string{err.Error()}
+	}
+
+	switch v := err.(type) {
 	// If the causal error is a terror with retryability set, inherit that value.
 	// Otherwise, we'll default to retryable based on the ErrInternalService code above.
 	// This allows us to have an non-retryable InternalService error if the cause was not-retryable,

--- a/errors_test.go
+++ b/errors_test.go
@@ -412,6 +412,14 @@ func TestNewInternalWithCauseStack(t *testing.T) {
 	assert.Contains(t, err.StackFrames[0].Method, "TestNewInternalWithCauseStack")
 }
 
+func TestNewInternalWithCauseMessageChain(t *testing.T) {
+	// Check non-terrors Errors are included at the base of the MessageChain
+	innerTerror := NewInternalWithCause(errors.New("wrapped error"), "inner terror", nil, "")
+	// Check that the message is included when the cause is a terrors Error too
+	outerTerror := NewInternalWithCause(innerTerror, "outer terror", nil, "")
+	assert.Equal(t, []string{"inner terror", "wrapped error"}, outerTerror.MessageChain)
+}
+
 func TestPropagate(t *testing.T) {
 	t.Run("terror", func(t *testing.T) {
 		terr := &Error{Code: "foo"}


### PR DESCRIPTION
Extends the functionality added in https://github.com/monzo/terrors/pull/45 for Augment to NewInternalWithCause.