### PR TITLE
New 'fatal' error to represent unrecoverable failures.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -40,6 +40,7 @@ const (
 	ErrUnauthorized       = "unauthorized"
 	ErrUnknown            = "unknown"
 	ErrRateLimited        = "rate_limited"
+	ErrFatal              = "fatal"
 )
 
 var retryableCodes = []string{

--- a/errors_test.go
+++ b/errors_test.go
@@ -58,6 +58,9 @@ func TestErrorConstructors(t *testing.T) {
 		{
 			RateLimited, "service.foo", "rate_limited.service.foo", nil, ErrRateLimited,
 		},
+		{
+			Fatal, "service.foo", "fatal.service.foo", nil, ErrFatal,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -199,6 +202,7 @@ func TestIsRetryable(t *testing.T) {
 	assert.True(t, IsRetryable(Augment(errors.New(""), "", nil)))
 	assert.True(t, IsRetryable(Wrap(errors.New(""), nil)))
 	assert.False(t, IsRetryable(WrapWithCode(errors.New(""), nil, ErrBadRequest)))
+	assert.False(t, IsRetryable(Fatal("", "", nil)))
 
 	// Check that IsRetryable honors errors that implement terrors.retryableError
 	// (after already being converted to a terror)

--- a/factory.go
+++ b/factory.go
@@ -21,9 +21,12 @@ func Wrap(err error, params map[string]string) error {
 // an `Error`, it will add the params passed in to the params of the error
 // Deprecated: Use Augment instead. If you need to set the code of the error,
 // then you should return a new error instead. For example
-//  terrors.WrapWithCode(err, map[string]string{"foo": "bar"}, "bad_request.failed")
+//
+//	terrors.WrapWithCode(err, map[string]string{"foo": "bar"}, "bad_request.failed")
+//
 // would become
-//  terrors.BadRequest("failed", err.Error(), map[string]string{"foo": "bar"})
+//
+//	terrors.BadRequest("failed", err.Error(), map[string]string{"foo": "bar"})
 func WrapWithCode(err error, params map[string]string, code string) error {
 	if err == nil {
 		return nil
@@ -89,6 +92,12 @@ func PreconditionFailed(code, message string, params map[string]string) *Error {
 // and that the caller should back-off.
 func RateLimited(code, message string, params map[string]string) *Error {
 	return errorFactory(errCode(ErrRateLimited, code), message, params)
+}
+
+// Fatal creates a new error representing an unrecoverable failure.
+// Errors of this type are not considered retryable.
+func Fatal(code, message string, params map[string]string) *Error {
+	return errorFactory(errCode(ErrFatal, code), message, params)
 }
 
 // errorConstructor returns a `*Error` with the specified code, message and params.


### PR DESCRIPTION
We do not have a great way to communicate general, unrecoverable errors at the moment:
* `ErrInternalService` is general but it's considered retryable 
* `ErrUnknown` is general but it's also considered retryable
* `ErrBadResponse` is not retryable but it doesn't feel very general
* ...

While we could debate the current semantics of our error types the fact is that we're currently heavily invested in these semantics, making change impractical.

This PR introduces a new error type, `ErrFatal`.  This is intended to represent general, unrecoverable/non-retryable errors. 