### PR TITLE
Added functions that take an error and set the retryable flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ When using the the wrapping functionality (e.g. `Wrap`, `Augment`, `Propagate`),
 of an error is preserved as expected. Importantly, it is also preserved when constructing a new error from
 a causal error with `NewInternalWithCause`.
 
+Wrap an error with `Retryable` or `NotRetryable` to set the retryability explicitly. This will
+override the retryability derived from the error code.
+
+```go
+retryableErr := terrors.Retryable(terrors.Augment(err, "didn't work, let's try again", nil))
+if terrors.IsRetryable(retryableErr) {
+	// retry the operation
+}
+```
+
 ## API
 
 Full API documentation can be found on

--- a/errors.go
+++ b/errors.go
@@ -395,7 +395,7 @@ func Retryable(err error) error {
 	return terr
 }
 
-// Retryable converts the error to a terror if necessary, and marks it as not retryable.
+// NotRetryable converts the error to a terror if necessary, and marks it as not retryable.
 func NotRetryable(err error) error {
 	if err == nil {
 		return nil

--- a/errors.go
+++ b/errors.go
@@ -384,6 +384,28 @@ func IsRetryable(err error) bool {
 	return false
 }
 
+// Retryable converts the error to a terror if necessary, and marks it as retryable.
+func Retryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	// Using propagate ensures the error can be converted to a terror
+	terr := Propagate(err).(*Error)
+	terr.SetIsRetryable(true)
+	return terr
+}
+
+// Retryable converts the error to a terror if necessary, and marks it as not retryable.
+func NotRetryable(err error) error {
+	if err == nil {
+		return nil
+	}
+	// Using propagate ensures the error can be converted to a terror
+	terr := Propagate(err).(*Error)
+	terr.SetIsRetryable(false)
+	return terr
+}
+
 // Augment adds context to an existing error.
 // If the error given is not already a terror, a new terror is created.
 func Augment(err error, context string, params map[string]string) error {

--- a/errors_test.go
+++ b/errors_test.go
@@ -214,6 +214,21 @@ func TestIsRetryable(t *testing.T) {
 	assert.False(t, IsRetryable(&testRetryableError{false}))
 	assert.True(t, IsRetryable(&testRetryableError{true}))
 	assert.True(t, IsRetryable(&testRetryableError{true}))
+
+	// Setting using convenience functions
+	assert.True(t, IsRetryable(Retryable(errors.New(""))))
+	assert.False(t, IsRetryable(NotRetryable(errors.New(""))))
+	assert.True(t, IsRetryable(Retryable(Augment(errors.New(""), "", nil))))
+	assert.False(t, IsRetryable(NotRetryable(Augment(errors.New(""), "", nil))))
+
+	// Overriding the default for error types using convenience functions
+	assert.True(t, IsRetryable(Retryable(BadRequest("", "", nil))))
+	assert.True(t, IsRetryable(Retryable(BadResponse("", "", nil))))
+	assert.True(t, IsRetryable(Retryable(NotFound("", "", nil))))
+	assert.True(t, IsRetryable(Retryable(PreconditionFailed("", "", nil))))
+	assert.True(t, IsRetryable(Retryable(NonRetryableInternalService("", "", nil))))
+	assert.False(t, IsRetryable(NotRetryable(InternalService("", "", nil))))
+	assert.False(t, IsRetryable(NotRetryable(RateLimited("", "", nil))))
 }
 
 type testRetryableError struct {


### PR DESCRIPTION
The retryable flag is a great feature, but it's currently a pain to use.

This PR adds `terrors.Retryable(error) error` and `terrors.NotRetryable(error) error`.
