### PR TITLE
Stop initialising the IsUnexpected flag to false for new errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -218,7 +218,8 @@ func (p *Error) Retryable() bool {
 }
 
 // Unexpected states whether an error is not expected to occur. In many cases this will be due to a bug, e.g. due to a
-// defensive check failing
+// defensive check failing.
+// Note that if the IsUnexpected flag has not been set at all, this will still return false.
 func (p *Error) Unexpected() bool {
 	if p.IsUnexpected != nil {
 		return *p.IsUnexpected

--- a/errors_test.go
+++ b/errors_test.go
@@ -575,7 +575,7 @@ func TestSetIsRetryable(t *testing.T) {
 
 func TestSetIsUnexpected(t *testing.T) {
 	err := New("code", "message", nil)
-	assert.False(t, *err.IsUnexpected)
+	assert.Nil(t, err.IsUnexpected)
 
 	err.SetIsUnexpected(true)
 	assert.True(t, *err.IsUnexpected)

--- a/factory.go
+++ b/factory.go
@@ -117,10 +117,9 @@ func RateLimited(code, message string, params map[string]string) *Error {
 // Builds a stack based on the current call stack
 func errorFactory(code string, message string, params map[string]string) *Error {
 	err := &Error{
-		Code:         ErrUnknown,
-		Message:      message,
-		Params:       map[string]string{},
-		IsUnexpected: &notUnexpected,
+		Code:    ErrUnknown,
+		Message: message,
+		Params:  map[string]string{},
 	}
 	if len(code) > 0 {
 		err.Code = code


### PR DESCRIPTION
The `IsUnexpected` flag has predominately been designed to support the case that you have an "expected" error (e.g. validation errors that would lead to a 400-like error code) that should actually be seen as "unexpected" (e.g. because the params being validated come from code and not user input), and so fail more noisily.

However there is also a sort-of-opposite scenario, where an "unexpected" error wants to be perceived as "expected". An example might be a downstream error from Service B bubbling up to Service A, where Service A handling this error doesn't need to _also_ fail noisily in certain circumstances (e.g. a different team owning each service, where the error will just be noise to the owners of Service A).

This flag has the potential to support this second scenario too, as it has 3 values: nil, true or false. However, we currently initialise all new errors with false, meaning in reality this flag will never be nil, and it's impossible to differentiate between "expected" errors and "normal" errors (ones where we've not set this flag either way, and the normal logic should apply).

This PR changes the default for new errors to not initialise this flag (i.e. it will be nil). This should be a safe change, as long as any calling logic handles the potential nil pointer correctly already - you should check this before pulling in this change.