### PR TITLE
Add helper to set precondition failed as unexpected

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -48,12 +48,15 @@ func TestErrorConstructors(t *testing.T) {
 		},
 		{
 			Unauthorized, "service.foo", "test params", map[string]string{
-				"some key":    "some value",
-				"another key": "another value",
-			}, ErrUnauthorized,
+			"some key":    "some value",
+			"another key": "another value",
+		}, ErrUnauthorized,
 		},
 		{
 			PreconditionFailed, "service.foo", "precondition_failed.service.foo", nil, ErrPreconditionFailed,
+		},
+		{
+			UnexpectedPreconditionFailed, "service.foo", "precondition_failed.service.foo", nil, ErrPreconditionFailed,
 		},
 		{
 			RateLimited, "service.foo", "rate_limited.service.foo", nil, ErrRateLimited,
@@ -530,34 +533,39 @@ func TestRetryable(t *testing.T) {
 
 func TestUnexpected(t *testing.T) {
 	cases := []struct {
-		name   string
-		terr   Error
-		expect bool
+		name string
+		terr *Error
+		want bool
 	}{
 		{
-			name:   "default",
-			terr:   Error{},
-			expect: false,
+			name: "default",
+			terr: &Error{},
+			want: false,
 		},
 		{
 			name: "unexpected",
-			terr: Error{
+			terr: &Error{
 				IsUnexpected: &unexpected,
 			},
-			expect: true,
+			want: true,
 		},
 		{
 			name: "not unexpected",
-			terr: Error{
+			terr: &Error{
 				IsUnexpected: &notUnexpected,
 			},
-			expect: false,
+			want: false,
+		},
+		{
+			name: "unexpected precondition failed",
+			terr: UnexpectedPreconditionFailed("code", "message", nil),
+			want: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(t.Name(), func(t *testing.T) {
-			assert.Equal(t, tc.expect, tc.terr.Unexpected())
+			assert.Equal(t, tc.want, tc.terr.Unexpected())
 		})
 	}
 }

--- a/factory.go
+++ b/factory.go
@@ -102,9 +102,20 @@ func Unauthorized(code, message string, params map[string]string) *Error {
 }
 
 // PreconditionFailed creates a new error indicating that one or more conditions
-// given in the request evaluated to false when tested on the server.
+// given in the request evaluated to false when tested on the server
+// or entities are in an invalid state in the server for the requested operation.
 func PreconditionFailed(code, message string, params map[string]string) *Error {
 	return errorFactory(errCode(ErrPreconditionFailed, code), message, params)
+}
+
+// UnexpectedPreconditionFailed creates a new error indicating that one or more conditions
+// given in the request evaluated to false when tested on the server
+// or entities are in an invalid state in the server for the requested operation.
+// Errors returned by this function are considered to be unexpected by default.
+func UnexpectedPreconditionFailed(code, message string, params map[string]string) *Error {
+	terr := PreconditionFailed(code, message, params)
+	terr.SetIsUnexpected(true)
+	return terr
 }
 
 // RateLimited creates a new error indicating that the request has been rate-limited,


### PR DESCRIPTION
This PR creates a helper to set unexpected as true in `PreconditionFailed` error.  `PreconditionFailed` are treated as expected errors by default and hence logged with warn severity.

This helper would be used in scenarios where we would like to alert when entities are not in a correct state in the server for the requested operation from the caller and treat those as unexpected.
[Discussion context](https://monzo.slack.com/archives/C6CDCNCS1/p1753982103787239)